### PR TITLE
Update recon to 2.3.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ReconEx.Mixfile do
   end
 
   defp deps do [
-    {:recon, "~> 2.3.1", compile: "rebar compile"},
+    {:recon, "~> 2.3.1", manager: :rebar},
     {:ex_doc, "~> 0.10.0", only: :dev},
     {:earmark, "~> 0.1", only: :dev}
     # {:markdown, github: "devinus/markdown", only: :test}

--- a/mix.exs
+++ b/mix.exs
@@ -23,10 +23,7 @@ defmodule ReconEx.Mixfile do
   end
 
   defp deps do [
-    # ReconTrace reqires recon 2.3.0 or newer, which is not released yet.
-    # Get it from GitHub.
-    # {:recon, "~> 2.3.0"},
-    {:recon, github: "ferd/recon"},
+    {:recon, "~> 2.3.1", compile: "rebar compile"},
     {:ex_doc, "~> 0.10.0", only: :dev},
     {:earmark, "~> 0.1", only: :dev}
     # {:markdown, github: "devinus/markdown", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "recon": {:git, "https://github.com/ferd/recon.git", "8913f36f12d6040307aa75f596bbf9ad3f6888a3", []}}
+  "recon": {:hex, :recon, "2.3.1"}}


### PR DESCRIPTION
As recon 2.3.1 was released, I updated recon to 2.3.1 in mix.exs.

Because recon at hex contains `rebar.config`, it is necessary to tell mix that recon is compiled with `rebar compile` and `rebar` is in PATH.
