### PR TITLE
Chore/bump recon version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ not want bleeding edge and development content for this library.
 Versions supported:
 
 - Elixir 1.1 or newer
-- Recon 2.3.0 or newer
+- Recon 2.5.0 or newer
 
 
 ## Try Them Out

--- a/lib/recon.ex
+++ b/lib/recon.ex
@@ -88,7 +88,7 @@ defmodule Recon do
 
   @type inet_attrs :: {port, attr :: term, [{atom, term}]}
 
-  @type pid_term :: pid | atom | char_list()
+  @type pid_term :: pid | atom | charlist
                     | {:global, term} | {:via, module, term}
                     | {non_neg_integer, non_neg_integer, non_neg_integer}
 
@@ -111,7 +111,7 @@ defmodule Recon do
   @type time_ms :: pos_integer
   @type timeout_ms :: non_neg_integer | :infinity
 
-  @type port_term :: port | char_list | atom | pos_integer
+  @type port_term :: port | charlist | atom | pos_integer
 
   @type port_info_type :: :meta | :signals | :io | :memory_used | :specific
 
@@ -407,7 +407,7 @@ defmodule Recon do
   Shows a list of all different ports on the node with their
   respective types.
   """
-  @spec port_types :: [{type :: char_list, count :: pos_integer}]
+  @spec port_types :: [{type :: charlist, count :: pos_integer}]
   def port_types(), do: :recon.port_types
 
   @doc """

--- a/lib/recon.ex
+++ b/lib/recon.ex
@@ -78,34 +78,41 @@ defmodule Recon do
   ### TYPES ###
   #############
 
-  @type proc_attrs :: {pid,
-                       attr :: term,
-                       [name :: atom
-                        | {:current_function, mfa}
-                        | {:initial_call, mfa}, ...]}
+  @type proc_attrs ::
+          {pid, attr :: term,
+           [
+             name ::
+               atom
+               | {:current_function, mfa}
+               | {:initial_call, mfa},
+             ...
+           ]}
 
   @type inet_attr_name :: :recv_cnt | :recv_oct | :send_cnt | :send_oct | :cnt | :oct
 
   @type inet_attrs :: {port, attr :: term, [{atom, term}]}
 
-  @type pid_term :: pid | atom | charlist
-                    | {:global, term} | {:via, module, term}
-                    | {non_neg_integer, non_neg_integer, non_neg_integer}
+  @type pid_term ::
+          pid
+          | atom
+          | charlist
+          | {:global, term}
+          | {:via, module, term}
+          | {non_neg_integer, non_neg_integer, non_neg_integer}
 
   @type info_type :: :meta | :signals | :location | :memory_used | :work
 
   @type info_meta_key :: :registered_name | :dictionary | :group_leader | :status
   @type info_signals_key :: :links | :monitors | :monitored_by | :trap_exit
   @type info_location_key :: :initial_call | :current_stacktrace
-  @type info_memory_key :: :memory | :message_queue_len | :heap_size
-                           | :total_heap_size | :garbage_collection
+  @type info_memory_key ::
+          :memory | :message_queue_len | :heap_size | :total_heap_size | :garbage_collection
   @type info_work_key :: :reductions
 
-  @type info_key :: info_meta_key | info_signals_key | info_location_key
-                    | info_memory_key | info_work_key
+  @type info_key ::
+          info_meta_key | info_signals_key | info_location_key | info_memory_key | info_work_key
 
-  @type stats :: {[absolutes  :: {atom, term}],
-                  [increments :: {atom, term}]}
+  @type stats :: {[absolutes :: {atom, term}], [increments :: {atom, term}]}
 
   @type interval_ms :: pos_integer
   @type time_ms :: pos_integer
@@ -121,9 +128,12 @@ defmodule Recon do
   @type port_info_memory_key :: :memory | :queue_size
   @type port_info_specific_key :: atom
 
-  @type port_info_key :: port_info_meta_key | port_info_signals_key
-                         | port_info_io_key | port_info_memory_key
-                         | port_info_specific_key
+  @type port_info_key ::
+          port_info_meta_key
+          | port_info_signals_key
+          | port_info_io_key
+          | port_info_memory_key
+          | port_info_specific_key
 
   @type nodes :: node | [node, ...]
   @type rpc_result :: {[success :: term], [fail :: term]}
@@ -138,16 +148,16 @@ defmodule Recon do
   Equivalent to `info(<a.b.c>)` where `a`, `b`, and `c` are integers
   part of a pid.
   """
-  @spec info(non_neg_integer, non_neg_integer, non_neg_integer)
-            :: [{info_type, [{info_key, term}]}, ...]
+  @spec info(non_neg_integer, non_neg_integer, non_neg_integer) ::
+          [{info_type, [{info_key, term}]}, ...]
   def info(a, b, c), do: :recon.info(a, b, c)
 
   @doc """
   Equivalent to `info(<a.b.c>, key)` where `a`, `b`, and `c` are
   integers part of a pid.
   """
-  @spec info(non_neg_integer, non_neg_integer, non_neg_integer,
-             key :: info_type | [atom] | atom) :: term
+  @spec info(non_neg_integer, non_neg_integer, non_neg_integer, key :: info_type | [atom] | atom) ::
+          term
   def info(a, b, c, key), do: :recon.info(a, b, c, key)
 
   @doc """
@@ -167,7 +177,7 @@ defmodule Recon do
   """
   @spec info(pid_term) :: [{info_type, [{info_key, value :: term}]}, ...]
   def info(pid_term) do
-    ReconLib.term_to_pid(pid_term) |> :recon.info
+    ReconLib.term_to_pid(pid_term) |> :recon.info()
   end
 
   @doc """
@@ -238,9 +248,11 @@ defmodule Recon do
   differentiate them. This can take a heavy toll on memory when you
   have many dozens of thousands of processes.
   """
-  @spec proc_window(attribute_name :: atom,
-                    non_neg_integer,
-                    milliseconds :: pos_integer) :: [proc_attrs]
+  @spec proc_window(
+          attribute_name :: atom,
+          non_neg_integer,
+          milliseconds :: pos_integer
+        ) :: [proc_attrs]
   def proc_window(attr_name, num, time) do
     :recon.proc_window(attr_name, num, time)
   end
@@ -269,10 +281,11 @@ defmodule Recon do
   """
   @spec node_stats_print(repeat :: non_neg_integer, interval_ms) :: term
   def node_stats_print(n, interval) do
-    fold_fun = fn(x, _) ->
+    fold_fun = fn x, _ ->
       IO.inspect(x, pretty: true)
       :ok
     end
+
     node_stats(n, interval, fold_fun, :ok)
   end
 
@@ -294,8 +307,8 @@ defmodule Recon do
 
   A scheduler isn't busy when doing anything else.
   """
-  @spec scheduler_usage(interval_ms)
-           :: [{scheduler_id :: pos_integer, usage :: number()}]
+  @spec scheduler_usage(interval_ms) ::
+          [{scheduler_id :: pos_integer, usage :: number()}]
   def scheduler_usage(interval) when is_integer(interval) do
     :recon.scheduler_usage(interval)
   end
@@ -325,11 +338,13 @@ defmodule Recon do
   of garbage collector runs, words of memory that were garbage
   collected, and the global reductions count for the node.
   """
-  @spec node_stats(non_neg_integer,
-                   interval_ms,
-                   fold_fun :: ((stats, acc :: term) -> term),
-                   acc0 :: term)
-        :: (acc1 :: term)
+  @spec node_stats(
+          non_neg_integer,
+          interval_ms,
+          fold_fun :: (stats, acc :: term -> term),
+          acc0 :: term
+        ) ::
+          acc1 :: term
   def node_stats(n, interval, fold_fun, init) do
     :recon.node_stats(n, interval, fold_fun, init)
   end
@@ -383,32 +398,32 @@ defmodule Recon do
   Returns a list of all TCP ports (the data type) open on the node.
   """
   @spec tcp :: [port]
-  def tcp(), do: :recon.tcp
+  def tcp(), do: :recon.tcp()
 
   @doc """
   Returns a list of all UDP ports (the data type) open on the node.
   """
   @spec udp :: [port]
-  def udp(), do: :recon.udp
+  def udp(), do: :recon.udp()
 
   @doc """
   Returns a list of all SCTP ports (the data type) open on the node.
   """
   @spec sctp :: [port]
-  def sctp(), do: :recon.sctp
+  def sctp(), do: :recon.sctp()
 
   @doc """
   Returns a list of all file handles open on the node.
   """
   @spec files :: [port]
-  def files(), do: :recon.files
+  def files(), do: :recon.files()
 
   @doc """
   Shows a list of all different ports on the node with their
   respective types.
   """
   @spec port_types :: [{type :: charlist, count :: pos_integer}]
-  def port_types(), do: :recon.port_types
+  def port_types(), do: :recon.port_types()
 
   @doc """
   Fetches a given attribute from all inet ports (TCP, UDP, SCTP) and
@@ -464,10 +479,10 @@ defmodule Recon do
   The information-specific and the basic port info are sorted and
   categorized in broader categories (`port_info_type()`).
   """
-  @spec port_info(port_term)
-          :: [{port_info_type, [{port_info_key, term}]}, ...]
+  @spec port_info(port_term) ::
+          [{port_info_type, [{port_info_key, term}]}, ...]
   def port_info(port_term) do
-    ReconLib.term_to_port(port_term) |> :recon.port_info
+    ReconLib.term_to_port(port_term) |> :recon.port_info()
   end
 
   @doc """
@@ -483,13 +498,14 @@ defmodule Recon do
   accepted by `:erlang.port_info/2` are accepted, and lists of them
   too.
   """
-  @spec port_info(port_term, port_info_type)
-         :: {port_info_type, [{port_info_key, term}]}
+  @spec port_info(port_term, port_info_type) ::
+          {port_info_type, [{port_info_key, term}]}
   @spec port_info(port_term, [atom]) :: [{atom, term}]
   @spec port_info(port_term, atom) :: {atom, term}
   def port_info(port_term, type_or_keys) when is_binary(port_term) do
     to_char_list(port_term) |> :recon.port_info(type_or_keys)
   end
+
   def port_info(port_term, type_or_keys) do
     :recon.port_info(port_term, type_or_keys)
   end
@@ -533,5 +549,4 @@ defmodule Recon do
   """
   @spec named_rpc(nodes, (() -> term), timeout_ms) :: rpc_result
   def named_rpc(nodes, fun, timeout), do: :recon.named_rpc(nodes, fun, timeout)
-
 end

--- a/lib/recon_alloc.ex
+++ b/lib/recon_alloc.ex
@@ -88,16 +88,22 @@ defmodule ReconAlloc do
   ### TYPES ###
   #############
 
-  @type allocator :: :temp_alloc | :eheap_alloc | :binary_alloc | :ets_alloc
-                      | :driver_alloc | :sl_alloc | :ll_alloc | :fix_alloc
-                      | :std_alloc
+  @type allocator ::
+          :temp_alloc
+          | :eheap_alloc
+          | :binary_alloc
+          | :ets_alloc
+          | :driver_alloc
+          | :sl_alloc
+          | :ll_alloc
+          | :fix_alloc
+          | :std_alloc
   @type instance :: non_neg_integer
   @type allocdata(t) :: {{allocator, instance}, t}
 
   # Snapshot handling
   @type memory :: [{atom, atom}]
   @type snapshot :: {memory, [allocdata(term)]}
-
 
   ##############
   ### Public ###
@@ -108,8 +114,8 @@ defmodule ReconAlloc do
   """
   @spec memory(:used | :allocated | :unused) :: pos_integer
   @spec memory(:usage) :: number
-  @spec memory(:allocated_types | :allocated_instances)
-                 :: [{allocator, pos_integer}]
+  @spec memory(:allocated_types | :allocated_instances) ::
+          [{allocator, pos_integer}]
   def memory(key), do: :recon_alloc.memory(key)
 
   @doc """
@@ -148,8 +154,8 @@ defmodule ReconAlloc do
   """
   @spec memory(:used | :allocated | :unused, :current | :max) :: pos_integer
   @spec memory(:usage, :current | :max) :: number
-  @spec memory(:allocated_types | :allocated_instances, :current | :max)
-                 :: [{allocator, pos_integer}]
+  @spec memory(:allocated_types | :allocated_instances, :current | :max) ::
+          [{allocator, pos_integer}]
   def memory(type, keyword), do: :recon_alloc.memory(type, keyword)
 
   @doc """
@@ -197,9 +203,8 @@ defmodule ReconAlloc do
   combining the lower cache hit joined to the largest memory values
   allocated.
   """
-  @spec cache_hit_rates() :: [{{:instance, instance},
-                               [{:hit_rate | :hits | :calls, term}]}]
-  def cache_hit_rates(), do: :recon_alloc.cache_hit_rates
+  @spec cache_hit_rates() :: [{{:instance, instance}, [{:hit_rate | :hits | :calls, term}]}]
+  def cache_hit_rates(), do: :recon_alloc.cache_hit_rates()
 
   @doc """
   Checks all allocators in `allocator/0` and returns the average block
@@ -218,8 +223,8 @@ defmodule ReconAlloc do
   Do note that values for `lmbcs` and `smbcs` are going to be rounded
   up to the next power of two when configuring them.
   """
-  @spec average_block_sizes(:current | :max)
-                             :: [{allocator, [{:mbcs, :sbcs, number}]}]
+  @spec average_block_sizes(:current | :max) ::
+          [{allocator, [{:mbcs, :sbcs, number}]}]
   def average_block_sizes(keyword) do
     :recon_alloc.average_block_sizes(keyword)
   end
@@ -258,7 +263,7 @@ defmodule ReconAlloc do
   Returns a dump of all allocator settings and values.
   """
   @spec allocators() :: [allocdata(term)]
-  def allocators(), do: :recon_alloc.allocators
+  def allocators(), do: :recon_alloc.allocators()
 
   #########################
   ### Snapshot handling ###
@@ -272,14 +277,14 @@ defmodule ReconAlloc do
   `snapshot_clear/1`.
   """
   @spec snapshot() :: snapshot | :undefined
-  def snapshot(), do: :recon_alloc.snapshot
+  def snapshot(), do: :recon_alloc.snapshot()
 
   @doc """
   Clear the current snapshot in the process dictionary, if present,
   and return the value it had before being unset.
   """
   @spec snapshot_clear() :: snapshot | :undefined
-  def snapshot_clear(), do: :recon_alloc.snapshot_clear
+  def snapshot_clear(), do: :recon_alloc.snapshot_clear()
 
   @doc """
   Prints a dump of the current snapshot stored by `snapshot/0`. Prints
@@ -287,7 +292,7 @@ defmodule ReconAlloc do
   """
   @spec snapshot_print() :: :ok
   def snapshot_print() do
-    IO.inspect :recon_alloc.snapshot_get, pretty: true
+    IO.inspect(:recon_alloc.snapshot_get(), pretty: true)
   end
 
   @doc """
@@ -295,14 +300,14 @@ defmodule ReconAlloc do
   `undefined` if no snapshot has been taken.
   """
   @spec snapshot_get() :: snapshot | :undefined
-  def snapshot_get(), do: :recon_alloc.snapshot_get
+  def snapshot_get(), do: :recon_alloc.snapshot_get()
 
   @doc """
   Save the current snapshot taken by `snapshot/0` to a file.If there
   is no current snapshot, a snaphot of the current allocator
   statistics will be written to the file.
   """
-  @spec snapshot_save(:file.name) :: :ok
+  @spec snapshot_save(:file.name()) :: :ok
   def snapshot_save(filename), do: :recon_alloc.snapshot_save(filename)
 
   @doc """
@@ -345,7 +350,7 @@ defmodule ReconAlloc do
   18411064
   ```
   """
-  @spec snapshot_load(:file.name) :: snapshot | :undefined
+  @spec snapshot_load(:file.name()) :: snapshot | :undefined
   def snapshot_load(filename), do: :recon_alloc.snapshot_load(filename)
 
   #########################
@@ -369,5 +374,4 @@ defmodule ReconAlloc do
   """
   @spec set_unit(:byte | :kilobyte | :megabyte | :gigabyte) :: :ok
   def set_unit(unit), do: :recon_alloc.set_unit(unit)
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ReconEx.Mixfile do
   end
 
   defp deps do [
-    {:recon, "~> 2.3.1", manager: :rebar},
+    {:recon, "~> 2.5", manager: :rebar},
     {:ex_doc, "~> 0.10.0", only: :dev},
     {:earmark, "~> 0.1", only: :dev}
     # {:markdown, github: "devinus/markdown", only: :test}

--- a/mix.exs
+++ b/mix.exs
@@ -4,30 +4,32 @@ defmodule ReconEx.Mixfile do
   @version "0.9.1"
 
   def project do
-    [app: :recon_ex,
-     version: @version,
-     elixir: "~> 1.1",
-     description: "Elixir wrapper for Recon, diagnostic tools for production use",
-     package: [
-       maintainers: ["Tatsuya Kawano"],
-       licenses: ["BSD 3-clause"],
-       links: %{"GitHub" => "https://github.com/tatsuya6502/recon_ex"}
-       ],
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps]
+    [
+      app: :recon_ex,
+      version: @version,
+      elixir: "~> 1.1",
+      description: "Elixir wrapper for Recon, diagnostic tools for production use",
+      package: [
+        maintainers: ["Tatsuya Kawano"],
+        licenses: ["BSD 3-clause"],
+        links: %{"GitHub" => "https://github.com/tatsuya6502/recon_ex"}
+      ],
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   def application do
     [applications: [:logger, :recon]]
   end
 
-  defp deps do [
-    {:recon, "~> 2.5", manager: :rebar},
-    {:ex_doc, "~> 0.10.0", only: :dev},
-    {:earmark, "~> 0.1", only: :dev}
-    # {:markdown, github: "devinus/markdown", only: :test}
-  ]
+  defp deps do
+    [
+      {:recon, "~> 2.5", manager: :rebar},
+      {:ex_doc, "~> 0.10.0", only: :dev},
+      {:earmark, "~> 0.1", only: :dev}
+      # {:markdown, github: "devinus/markdown", only: :test}
+    ]
   end
-
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm", "c86afb8d22a5aa8315afd4257c7512011c0c9a48b0fea43af7612836b958098b"},
   "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm", "3d9f15777aa3fb62700d5984eb09ceeb6c1574d61be0f70801e3390e36942b35"},
-  "recon": {:hex, :recon, "2.3.1", "281f2cbb439fe3c043773ee6c83172abd80326dcc6153f6430e4d4e6b14d7e9d", [:rebar3], [], "hexpm", "6d2c7363bb89afebd1241b00333ca1b2b09c611efd9468ac00eccf78d2403a04"},
+  "recon": {:hex, :recon, "2.5.1", "430ffa60685ac1efdfb1fe4c97b8767c92d0d92e6e7c3e8621559ba77598678a", [:mix, :rebar3], [], "hexpm", "5721c6b6d50122d8f68cccac712caa1231f97894bab779eff5ff0f886cb44648"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "recon": {:hex, :recon, "2.3.1"}}
+%{
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm", "c86afb8d22a5aa8315afd4257c7512011c0c9a48b0fea43af7612836b958098b"},
+  "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm", "3d9f15777aa3fb62700d5984eb09ceeb6c1574d61be0f70801e3390e36942b35"},
+  "recon": {:hex, :recon, "2.3.1", "281f2cbb439fe3c043773ee6c83172abd80326dcc6153f6430e4d4e6b14d7e9d", [:rebar3], [], "hexpm", "6d2c7363bb89afebd1241b00333ca1b2b09c611efd9468ac00eccf78d2403a04"},
+}

--- a/test/recon_trace_test.exs
+++ b/test/recon_trace_test.exs
@@ -52,7 +52,7 @@ defmodule ReconTraceTest do
 
   @spec make_shellfun(binary) :: (([term]) -> term)
   defp make_shellfun(fun_str) do
-     to_char_list(fun_str) |> :elixir.eval([]) |> elem(0)
+     to_char_list(fun_str) |> Code.eval_string([]) |> elem(0)
   end
 
   # defp make_shellfun_erl(erl_fun_str) do

--- a/test/recon_trace_test.exs
+++ b/test/recon_trace_test.exs
@@ -2,57 +2,50 @@ defmodule ReconTraceTest do
   use ExUnit.Case
   # doctest ReconTrace
 
-  import ReconTrace, only: [ to_erl_tspec: 1, format: 1 ]
+  import ReconTrace, only: [to_erl_tspec: 1, format: 1]
 
   test "to_erl_tspec/1" do
-    shellfun = make_shellfun "fn([n, _]) when n > 10 -> :ok end"
+    shellfun = make_shellfun("fn([n, _]) when n > 10 -> :ok end")
     matchspec = [{[:"$1", :_], [{:>, :"$1", 10}], [:ok]}]
 
-    assert to_erl_tspec({:queue, :in, shellfun})  == {:queue, :in, matchspec}
+    assert to_erl_tspec({:queue, :in, shellfun}) == {:queue, :in, matchspec}
     assert to_erl_tspec({:queue, :in, matchspec}) == {:queue, :in, matchspec}
-    assert to_erl_tspec({:queue, :in, 2})         == {:queue, :in, 2}
+    assert to_erl_tspec({:queue, :in, 2}) == {:queue, :in, 2}
 
-    shellfun = make_shellfun "fn([:item, _]) -> :return end"
+    shellfun = make_shellfun("fn([:item, _]) -> :return end")
     matchspec = [{[:item, :_], [], [{:return_trace}]}]
 
-    assert to_erl_tspec({:queue, :in, shellfun})  == {:queue, :in, matchspec}
+    assert to_erl_tspec({:queue, :in, shellfun}) == {:queue, :in, matchspec}
   end
 
   test "format/1 for :call" do
-    ts = :os.timestamp
+    ts = :os.timestamp()
 
     # Format an Elixir module call with atom and function
-    assert (format({:trace_ts,
-                    pid(0, 1, 2),
-                    :call, {Emum, :each, [[:hello, "world"], &IO.puts/1]},
-                    ts})
-            == '\n#{format_timestamp ts} <0.1.2> Emum.each([:hello, "world"], &IO.puts/1)\n')
+    assert format(
+             {:trace_ts, pid(0, 1, 2), :call, {Emum, :each, [[:hello, "world"], &IO.puts/1]}, ts}
+           ) ==
+             '\n#{format_timestamp(ts)} <0.1.2> Emum.each([:hello, "world"], &IO.puts/1)\n'
 
     # Format an Erlang module call
-    assert (format({:trace_ts,
-                    pid(0, 1, 2),
-                    :call, {:lists, :seq, [1, 10]},
-                    ts})
-            == '\n#{format_timestamp ts} <0.1.2> :lists.seq(1, 10)\n')
+    assert format({:trace_ts, pid(0, 1, 2), :call, {:lists, :seq, [1, 10]}, ts}) ==
+             '\n#{format_timestamp(ts)} <0.1.2> :lists.seq(1, 10)\n'
   end
 
   test "format/1 for :return_to" do
-    ts = :os.timestamp
+    ts = :os.timestamp()
 
-    assert (format({:trace_ts,
-                    pid(0, 1, 2),
-                    :return_from, {Emum, :each, 2}, :ok,
-                    ts})
-            == '\n#{format_timestamp ts} <0.1.2> Emum.each/2 --> :ok\n')
+    assert format({:trace_ts, pid(0, 1, 2), :return_from, {Emum, :each, 2}, :ok, ts}) ==
+             '\n#{format_timestamp(ts)} <0.1.2> Emum.each/2 --> :ok\n'
   end
 
   #################
   ### Utilities ###
   #################
 
-  @spec make_shellfun(binary) :: (([term]) -> term)
+  @spec make_shellfun(binary) :: ([term] -> term)
   defp make_shellfun(fun_str) do
-     to_char_list(fun_str) |> Code.eval_string([]) |> elem(0)
+    to_char_list(fun_str) |> Code.eval_string([]) |> elem(0)
   end
 
   # defp make_shellfun_erl(erl_fun_str) do
@@ -63,12 +56,12 @@ defmodule ReconTraceTest do
   # end
 
   defp pid(a, b, c) do
-    :erlang.list_to_pid '<#{a}.#{b}.#{c}>'
+    :erlang.list_to_pid('<#{a}.#{b}.#{c}>')
   end
 
-  defp to_hms({_, _, micro}=ts) do
+  defp to_hms({_, _, micro} = ts) do
     {_, {h, m, secs}} = :calendar.now_to_local_time(ts)
-    seconds = rem(secs, 60) + (micro / 1_000_000)
+    seconds = rem(secs, 60) + micro / 1_000_000
     {h, m, seconds}
   end
 
@@ -79,5 +72,4 @@ defmodule ReconTraceTest do
   defp format_timestamp(ts) do
     to_hms(ts) |> format_hms
   end
-
 end


### PR DESCRIPTION
This PR aims to use a newer version of recon.


What did I do:

- formatted the files with the mix test

- updated the version of recon lib

- solved the warnings by removing deprecated types

- solved the tests using a deprecated function