### PR TITLE
Cleanup 2 problems on OTP25

### DIFF
--- a/lib/recon.ex
+++ b/lib/recon.ex
@@ -503,7 +503,7 @@ defmodule Recon do
   @spec port_info(port_term, [atom]) :: [{atom, term}]
   @spec port_info(port_term, atom) :: {atom, term}
   def port_info(port_term, type_or_keys) when is_binary(port_term) do
-    to_char_list(port_term) |> :recon.port_info(type_or_keys)
+    to_charlist(port_term) |> :recon.port_info(type_or_keys)
   end
 
   def port_info(port_term, type_or_keys) do

--- a/lib/recon_lib.ex
+++ b/lib/recon_lib.ex
@@ -113,11 +113,11 @@ defmodule ReconLib do
   end
 
   defp pre_process_pid_term(<<"#PID", pid_term::binary>>) do
-    to_char_list(pid_term)
+    to_charlist(pid_term)
   end
 
   defp pre_process_pid_term(pid_term) when is_binary(pid_term) do
-    to_char_list(pid_term)
+    to_charlist(pid_term)
   end
 
   defp pre_process_pid_term(pid_term) do
@@ -129,7 +129,7 @@ defmodule ReconLib do
   """
   @spec term_to_port(Recon.port_term()) :: port
   def term_to_port(term) when is_binary(term) do
-    to_char_list(term) |> :recon_lib.term_to_port()
+    to_charlist(term) |> :recon_lib.term_to_port()
   end
 
   def term_to_port(term) do

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ReconEx.Mixfile do
     [
       app: :recon_ex,
       version: @version,
-      elixir: "~> 1.1",
+      elixir: "~> 1.3",
       description: "Elixir wrapper for Recon, diagnostic tools for production use",
       package: [
         maintainers: ["Tatsuya Kawano"],

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule ReconEx.Mixfile do
 
   defp deps do
     [
-      {:recon, "~> 2.5", manager: :rebar},
+      {:recon, "~> 2.5", manager: :rebar3},
       {:ex_doc, "~> 0.10.0", only: :dev},
       {:earmark, "~> 0.1", only: :dev}
       # {:markdown, github: "devinus/markdown", only: :test}

--- a/test/recon_trace_test.exs
+++ b/test/recon_trace_test.exs
@@ -45,7 +45,7 @@ defmodule ReconTraceTest do
 
   @spec make_shellfun(binary) :: ([term] -> term)
   defp make_shellfun(fun_str) do
-    to_char_list(fun_str) |> Code.eval_string([]) |> elem(0)
+    to_charlist(fun_str) |> Code.eval_string([]) |> elem(0)
   end
 
   # defp make_shellfun_erl(erl_fun_str) do


### PR DESCRIPTION
First problem:
```
== Compilation error in file lib/recon.ex ==
** (CompileError) lib/recon.ex:2: module :recon is not loaded and could not be found. This may be happening because the module you are trying to load directly or indirectly depends on the current module

could not compile dependency :recon_ex, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile recon_ex", update it with "mix deps.update recon_ex" or clean it with "mix deps.clean recon_ex"
```
Solution: set manager to rebar3. Works now

Second problem:
```
==> recon_ex
Compiling 4 files (.ex)
warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1 instead
  lib/recon_lib.ex:116: ReconLib.pre_process_pid_term/1

warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1 instead
  lib/recon_lib.ex:120: ReconLib.pre_process_pid_term/1

warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1 instead
  lib/recon_lib.ex:132: ReconLib.term_to_port/1

warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1 instead
  lib/recon.ex:506: Recon.port_info/2
```
Solution: replaced to_char_list with to_charlist. Updated minimal required version of elixir to 1.3